### PR TITLE
Allow matchers to be used as a expected value for include

### DIFF
--- a/lib/rspec/hal/matchers/hal_matcher_helpers.rb
+++ b/lib/rspec/hal/matchers/hal_matcher_helpers.rb
@@ -1,7 +1,10 @@
+require 'forwardable'
+
 module RSpec
   module Hal
     module Matchers
       module HalMatcherHelpers
+        extend Forwardable
 
         # A matcher that always matches. Useful for avoiding special
         # cases in value testing logic.
@@ -29,6 +32,8 @@ module RSpec
           @repr = parse jsonish
         end
         attr_reader :repr
+
+        def_delegator :self, :matches?, :===
 
         # Returns string composed of the specified clauses with proper
         # spacing between them. Empty and nil clauses are ignored.

--- a/lib/rspec/hal/version.rb
+++ b/lib/rspec/hal/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Hal
-    VERSION = "1.4.1"
+    VERSION = "1.5.0"
   end
 end


### PR DESCRIPTION
``` ruby
expect(activations).to include have_relation "http://schema.org/object", eq(strategy_url)
```
